### PR TITLE
Major update due to NIH-OPA's iCite data change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@
     Now the existing command to find one or more PMIDs must be used to find a single PMID:
         NOW: https://icite.od.nih.gov/api/pubs/33031632
 * UPDATE CITATION.cff
+* ADD `--version`` option to pmidcite's `icite` command
 
 ### release 2024-06-20 v0.0.48
 * ADD function, get_dict(), to get a dict containing data member values from the NIHiCiteEntry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@
 
 ### Unreleased
 
-### release 2025-07-23 v0.1.0
+### release 2025-07-23 v0.1.1
 * UPDATE for new NIH iCite format:
   * authors is now a dict w/keys firstName lastName & fullName rather than a str
   * These fields have True/False values rather than 'Yes' and 'No'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ## Summary
 
 * [**Unreleased**](#unreleased)
-* [**Release 2025-07-23 v0.1.0**](#release-2025-07-23-v010) Updated for new NIH iCite format for authors, and the True/False fields
+* [**Release 2025-07-24 v0.1.2**](#release-2025-07-24-v012) Updated for new NIH iCite format for authors, and the True/False fields
 * **Release 2025-05-06 v0.0.50** Removed setup.py
 * **Release 2025-05-06 v0.0.49** Add pyproject.toml
 * [**Release 2024-02-05 v0.0.48**](#release-2024-06-20-v0048) Update apikey; add get_dict(); update README.md
@@ -54,16 +54,18 @@
 
 ### Unreleased
 
-### release 2025-07-23 v0.1.1
+### release 2025-07-24 v0.1.2
 * UPDATE for new NIH iCite format:
   * authors is now a dict w/keys firstName lastName & fullName rather than a str
   * These fields have True/False values rather than 'Yes' and 'No'
     * is_research_article
     * is_clinical
     * provisional
-  * API Update to match NIH's new format to download iCite data for a single PMID:
-    * NOW: https://icite.od.nih.gov/api/pubs/33031632
-    * WAS: https://icite.od.nih.gov/api/pubs?33031632
+  * The command to get data for a single PMID is gone and was:    
+        WAS: https://icite.od.nih.gov/api/pubs?33031632 (This request format is now gone)
+    Now the existing command to find one or more PMIDs must be used to find a single PMID:
+        NOW: https://icite.od.nih.gov/api/pubs/33031632
+* UPDATE CITATION.cff
 
 ### release 2024-06-20 v0.0.48
 * ADD function, get_dict(), to get a dict containing data member values from the NIHiCiteEntry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ## Summary
 
 * [**Unreleased**](#unreleased)
-* [**Release 2025-07-03 v0.0.51**](#release-2025-07-03-v0051) Updated for new NIH iCite format for authors, and the True/False fields
+* [**Release 2025-07-23 v0.1.0**](#release-2025-07-23-v010) Updated for new NIH iCite format for authors, and the True/False fields
 * **Release 2025-05-06 v0.0.50** Removed setup.py
 * **Release 2025-05-06 v0.0.49** Add pyproject.toml
 * [**Release 2024-02-05 v0.0.48**](#release-2024-06-20-v0048) Update apikey; add get_dict(); update README.md
@@ -54,7 +54,7 @@
 
 ### Unreleased
 
-### release 2025-07-03 v0.0.51
+### release 2025-07-23 v0.1.0
 * UPDATE for new NIH iCite format:
   * authors is now a dict w/keys firstName lastName & fullName rather than a str
   * These fields have True/False values rather than 'Yes' and 'No'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -38,7 +38,6 @@ preferred-citation:
     given-names: "Will"
   doi: "10.1002/jrsm.1456"
   journal: "Research Synthesis Methods"
-  publisher: "Wiley"
   month: 3
   start: 126 # First page number
   end: 135 # Last page number
@@ -46,9 +45,6 @@ preferred-citation:
   issue: 2
   volume: 12
   year: 2021
-  pmid:33031632
-  eprint:33031632
-  eprinttype:pubmed
   keywords: 
     - CitedBy
     - PubMed

--- a/README.md
+++ b/README.md
@@ -8,16 +8,17 @@
 Turbocharge a [**PubMed**](https://pubmed.ncbi.nlm.nih.gov) literature search with the command, `icite`, rather than clicking and clicking and clicking on [**Google Scholar**](/doc/images/README_twitter.md) "*Cited by N*" links.
 
 This open-source project is part of [**a peer-reviewed**](https://pubmed.ncbi.nlm.nih.gov/33031632) [**commentary**](https://onlinelibrary.wiley.com/doi/10.1002/jrsm.1456) that was invited by the editors of [***Research Synthesis Methods***](https://onlinelibrary.wiley.com/journal/17592887).
-Please [**Cite**](#how-to-cite) if you use *pmidcite* in your research or literature search.    
+Please [**Cite**](#how-to-cite) and star on GitHub
+if you use *pmidcite* in your research or literature search.    
 
 Contact: dvklopfenstein@protonmail.com     
 
 # PubMed and NIH Citation data
 PubMed contains peer-reviewed research papers
-in biomedicine, biochemistry, chemistry, behavioral science, and other life sciences.
+in biomedicine, biochemistry, chemistry, behavioral science, and other life sciences.    
 [**Citation data**](https://icite.od.nih.gov) is downloaded
-each time `icite` is run
-from the [**National Institutes of Health (NIH)**](https://www.nih.gov/) and includes:
+from the [**National Institutes of Health (NIH)**](https://www.nih.gov/)
+each time `icite` is run and includes:
 * Citation counts of all papers and clinical papers
 * Performance of a paper among its peer papers
 * Existence of MeSH terms for the human, animal, and molecular/cellular categories

--- a/doc/NOTES.md
+++ b/doc/NOTES.md
@@ -1,0 +1,2 @@
+# About
+Turbocharge a PubMed literature search rather than clicking and clicking and clicking on Google Scholar's "Cited By" links

--- a/pmidcite/__init__.py
+++ b/pmidcite/__init__.py
@@ -2,6 +2,6 @@
 
 __copyright__ = 'Copyright (C) 2019-present, DV Klopfenstein, PhD. All rights reserved'
 __author__ = 'DV Klopfenstein, PhD'
-__version__ = '0.1.1'
+__version__ = '0.1.2'
 
 # Copyright (C) 2019-present, DV Klopfenstein, PhD. All rights reserved

--- a/pmidcite/__init__.py
+++ b/pmidcite/__init__.py
@@ -2,6 +2,6 @@
 
 __copyright__ = 'Copyright (C) 2019-present, DV Klopfenstein, PhD. All rights reserved'
 __author__ = 'DV Klopfenstein, PhD'
-__version__ = '0.1.0'
+__version__ = '0.1.1'
 
 # Copyright (C) 2019-present, DV Klopfenstein, PhD. All rights reserved

--- a/pmidcite/__init__.py
+++ b/pmidcite/__init__.py
@@ -2,6 +2,6 @@
 
 __copyright__ = 'Copyright (C) 2019-present, DV Klopfenstein, PhD. All rights reserved'
 __author__ = 'DV Klopfenstein, PhD'
-__version__ = '0.0.51'
+__version__ = '0.1.0'
 
 # Copyright (C) 2019-present, DV Klopfenstein, PhD. All rights reserved

--- a/pmidcite/cli/icite.py
+++ b/pmidcite/cli/icite.py
@@ -45,7 +45,10 @@ class NIHiCiteCli:
         # - PMIDs ----------------------------------------------------------------------------
         parser.add_argument(
             '-h', '--help', action='store_true',
-            help='print this help message and exit (also --help)')
+            help='Print this help message and exit (also --help)')
+        parser.add_argument(
+            '--version', action='store_true',
+            help="Print pmidcite's`icite` version number and exit")
         parser.add_argument(
             '--cite', action='store_true',
             help='publication citation for the pmidcite project')
@@ -194,6 +197,11 @@ class NIHiCiteCli:
     def _get_args(self, argparser):
         """Get args"""
         args = argparser.parse_args()
+        if args.version:
+            # pylint: disable=import-outside-toplevel
+            import pmidcite
+            print(f'icite {pmidcite.__version__}')
+            sys_exit()
         self.cfg.set_dir_icite_py(args.dir_icite_py)
         self.cfg.set_dir_icite(args.dir_icite)
         # append_outfile:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "pmidcite"
 description="Turbocharge a PubMed literature search using citation data from the NIH"
-version = "0.1.1"
+version = "0.1.2"
 license = "AGPL-3.0-or-later"
 authors = [
   {name = 'DV Klopfenstein, PhD', email = 'dvklopfenstein@protonmail.com'},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "pmidcite"
 description="Turbocharge a PubMed literature search using citation data from the NIH"
-version = "0.0.51"
+version = "0.1.0"
 license = "AGPL-3.0-or-later"
 authors = [
   {name = 'DV Klopfenstein, PhD', email = 'dvklopfenstein@protonmail.com'},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "pmidcite"
 description="Turbocharge a PubMed literature search using citation data from the NIH"
-version = "0.1.0"
+version = "0.1.1"
 license = "AGPL-3.0-or-later"
 authors = [
   {name = 'DV Klopfenstein, PhD', email = 'dvklopfenstein@protonmail.com'},
@@ -36,6 +36,7 @@ classifiers=[
   'Topic :: Scientific/Engineering :: Bio-Informatics',
   'Intended Audience :: Science/Research',
   'Intended Audience :: Developers',
+  'Intended Audience :: Information Technology',
   'Programming Language :: Python',
   'Environment :: Console',
   'Programming Language :: Python :: 3',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,9 @@ license = "AGPL-3.0-or-later"
 authors = [
   {name = 'DV Klopfenstein, PhD', email = 'dvklopfenstein@protonmail.com'},
 ]
+maintainers = [
+  {name = 'DV Klopfenstein, PhD', email = 'dvklopfenstein@protonmail.com'},
+]
 readme = {file="README.md", content-type="text/markdown"}
 
 keywords = [
@@ -37,9 +40,15 @@ classifiers=[
   'Intended Audience :: Science/Research',
   'Intended Audience :: Developers',
   'Intended Audience :: Information Technology',
-  'Programming Language :: Python',
   'Environment :: Console',
+  'Programming Language :: Python',
   'Programming Language :: Python :: 3',
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3 :: Only",
   'Operating System :: POSIX :: Linux',
   'Operating System :: POSIX',
   'Operating System :: Unix',
@@ -47,10 +56,14 @@ classifiers=[
 ]
 
 # Needed for assignment expressions & the walrus operator
-requires-python = '>=3.8'
+requires-python = '>=3.9'
 
 [project.urls]
-Homepage = "https://github.com/dvklopfenstein/pmidcite"
+"Homepage" = "https://github.com/dvklopfenstein/pmidcite"
+"Changelog" = "https://github.com/dvklopfenstein/pmidcite/blob/main/CHANGELOG.rst"
+"Documentation" = "https://dvklopfenstein.readthedocs.io"
+"Code" = "https://github.com/dvklopfenstein/pmidcite"
+"Issue tracker" = "https://github.com/dvklopfenstein/pmidcite/issues"
 
 [project.scripts]
 icite   = "pmidcite.scripts.icite:main"


### PR DESCRIPTION
The NIH-OPA's iCite data changed, which necessitated updating the `pmidcite` project.

Here are the iCite changes that affected `pmidcite`:
  * The "authors" field is now a dictionary with the keys, firstName lastName & fullName, rather than a simple string
  * These fields now have True/False values rather than the old string values of 'Yes' and 'No'
    * is_research_article
    * is_clinical
    * provisional
  * The command to get data for a single PMID is gone and was:
    * WAS: https://icite.od.nih.gov/api/pubs?33031632 (This request format is now gone)
    Now the existing command to find one or more PMIDs must be used to find a single PMID:
    * NOW: https://icite.od.nih.gov/api/pubs/33031632